### PR TITLE
Implement verified fix for issue #1.

### DIFF
--- a/etc/services.d/striparr/run
+++ b/etc/services.d/striparr/run
@@ -5,8 +5,8 @@ set -eo pipefail
 cd / || exit 1
 
 s6-setuidgid striparr /usr/bin/gunicorn \
-  -b \
-  0.0.0.0:40000 \
+  --bind 0.0.0.0:40000 \
+  --timeout 600 \
   striparr:app \
   2>&1 | awk '{print "[listener] " $0}'
 


### PR DESCRIPTION
Increase gunicorn worker timeout from default of 30 seconds to 10 minutes.
Reasoning is that during streaming large bodies, gunicorn thinks that the worker has died (busy streaming data, does not respond to keepalives). Tested by user reporting the problem that the increase in timeout solves the issue.