### PR TITLE
Fix for issue #4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@ FROM alpine:3
 
 RUN set -x && \
     apk add --no-cache \
-      python3 \
-      py3-pip \
-      py3-gunicorn \
-      redis \
+      bash \
       ffmpeg \
       gnupg \
+      py3-gunicorn \
+      py3-pip \
+      python3 \
+      redis \
       && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     ln -s /usr/bin/pip3 /usr/bin/pip && \
@@ -15,8 +16,8 @@ RUN set -x && \
       pip \
       && \
     pip install \
-      flask \
       celery \
+      flask \
       redis \
       requests \
       && \

--- a/etc/cont-init.d/01-striparr
+++ b/etc/cont-init.d/01-striparr
@@ -1,4 +1,5 @@
-#!/usr/bin/with-contenv sh
+#!/usr/bin/with-contenv bash
+#shellcheck shell=bash
 
 PGID=${PGID:-1000}
 PUID=${PUID:-1000}

--- a/etc/cont-init.d/01-striparr
+++ b/etc/cont-init.d/01-striparr
@@ -14,7 +14,7 @@ else
   echo $TZ > /etc/timezone
 fi
 
-addgroup -g ${PGID} striparr || exit 0
+addgroup -g ${PGID} striparr || true
 
 STRIPARR_GROUP=$(grep ":$PGID:" /etc/group | cut -d ":" -f 1)
 

--- a/etc/cont-init.d/01-striparr
+++ b/etc/cont-init.d/01-striparr
@@ -13,5 +13,8 @@ else
   echo $TZ > /etc/timezone
 fi
 
-addgroup -g ${PGID} striparr
-adduser -h /home/striparr -D -u ${PUID} -G striparr striparr
+addgroup -g ${PGID} striparr || exit 0
+
+STRIPARR_GROUP=$(grep ":$PGID:" /etc/group | cut -d ":" -f 1)
+
+adduser -h /home/striparr -D -u ${PUID} -G ${STRIPARR_GROUP} striparr

--- a/etc/services.d/celery/run
+++ b/etc/services.d/celery/run
@@ -1,4 +1,5 @@
-#!/usr/bin/with-contenv sh
+#!/usr/bin/with-contenv bash
+#shellcheck shell=bash
 
 set -eo pipefail
 
@@ -12,4 +13,3 @@ s6-setuidgid striparr /usr/bin/celery \
   --loglevel=warning \
   --concurrency 1 \
   2>&1 | awk '{print "[worker] " $0}'
-

--- a/etc/services.d/redis/run
+++ b/etc/services.d/redis/run
@@ -1,4 +1,5 @@
-#!/usr/bin/with-contenv sh
+#!/usr/bin/with-contenv bash
+#shellcheck shell=bash
 
 set -eo pipefail
 
@@ -6,7 +7,3 @@ cd / || exit 1
 
 /usr/bin/redis-server \
   > /dev/null 2>&1
-  #2>&1 | awk '{print "[redis] " $0}'
-  #> /dev/null 2>&1
-  #
-

--- a/etc/services.d/striparr/run
+++ b/etc/services.d/striparr/run
@@ -1,4 +1,5 @@
-#!/usr/bin/with-contenv sh
+#!/usr/bin/with-contenv bash
+#shellcheck shell=bash
 
 set -eo pipefail
 
@@ -9,4 +10,3 @@ s6-setuidgid striparr /usr/bin/gunicorn \
   --timeout 600 \
   striparr:app \
   2>&1 | awk '{print "[listener] " $0}'
-

--- a/striparr.py
+++ b/striparr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-__version__ = "2020-03-22"
+__version__ = "2020-04-11"
 
 import sys
 import os


### PR DESCRIPTION
If during container init `addgroup -g ${PGID} striparr` fails (presumably because the group already exists), lookup the name of the `GID` and use this instead of `striparr`.